### PR TITLE
Make uploaded avi and jpeg files browseable.

### DIFF
--- a/ftp.cpp
+++ b/ftp.cpp
@@ -84,6 +84,8 @@ static bool createFtpFolder(const char* folderName) {
   if (strcmp(respCodeRx, "550") == 0) {
     // non existent folder, create it
     if (!sendFtpCommand("MKD ", folderName, "257")) return false;
+    if (!sendFtpCommand("SITE CHMOD 755 ", folderName, "200"))
+       return false;
     if (!sendFtpCommand("CWD ", folderName, "250")) return false;         
   }
   return true;
@@ -157,6 +159,7 @@ static bool ftpStoreFile(File &fh) {
   percentLoaded = 100;
   if (sendFtpCommand("", "", "226")) LOG_ALT("Uploaded %0.1fMB in %u sec", (float)(writeBytes) / ONEMEG, (millis() - uploadStart) / 1000); 
   else LOG_ERR("File transfer not successful");
+  sendFtpCommand("SITE CHMOD 644 ", ftpSaveName, "200");
   return true;
 }
 


### PR DESCRIPTION
I want to have a club website which

1. is browsed by club members
2. have ftp uploaded files

The ftp uploaded files are created as no read permission for group and others. Therefore the files are not browser accessible.
I created an patch.
However, making the files in readable for all is a security risk. Is there any way to give read permission only for my devices?
